### PR TITLE
hostap: switch to John Crispin's fork

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -4,13 +4,16 @@
 	<remote name="prpl" fetch="ssh://git@github.com/prplfoundation" />
 	<remote name="nanomsg" fetch="ssh://git@github.com/nanomsg" />
 	<remote name="rurban" fetch="ssh://git@github.com/rurban" />
+	<remote name="blogic" fetch="https://github.com/blogic" />
 
 	<default revision="master" remote="prpl" sync-j="4" />
 
 	<project path="prplMesh" name="prplMesh"/>
-	<project path="hostap" name="hostap"/>
 	<project path="hostap/dwpal" name="dwpal"/>
 	
+	<!-- hostapd fork from blogic -->
+	<project path="hostap" remote="blogic" name="hostapd" revision="prpl-mesh"/>
+
 	<!-- upstream nng -->
 	<project path="3rdparty/nng" remote="nanomsg" name="nng" revision="90467583b7544b68483334070518e29b00ec6d81" />
 


### PR DESCRIPTION
John Crispin (@blogic) is implementing the commands that are required
for prplMesh in his prpl-mesh branch of hostapd. Switch to this repo and
branch.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>