### PR TITLE
default.xml: deliver boardfarm alongside prplMesh

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,18 +2,8 @@
 
 <manifest>
     <remote name="prpl" fetch="https://github.com/prplfoundation/" pushurl="ssh://git@github.com/prplfoundation" />
-    <remote name="nanomsg" fetch="https://github.com/nanomsg/" />
-    <remote name="rurban" fetch="https://github.com/rurban/" />
 
 	<default revision="master" remote="prpl" sync-j="4" />
 
 	<project path="prplMesh" name="prplMesh"/>
-	<project path="hostap" name="hostap" revision="prpl-mesh"/>
-	<project path="hostap/dwpal" name="dwpal"/>
-
-	<!-- upstream nng -->
-	<project path="3rdparty/nng" remote="nanomsg" name="nng" revision="90467583b7544b68483334070518e29b00ec6d81" />
-
-	<!-- upstream safelibc -->
-	<project path="3rdparty/safeclib" remote="rurban"  name="safeclib" revision="ab130d7376267b6deb55e194746fc08d045afa61" />
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -3,7 +3,8 @@
 <manifest>
     <remote name="prpl" fetch="https://github.com/prplfoundation/" pushurl="ssh://git@github.com/prplfoundation" />
 
-	<default revision="master" remote="prpl" sync-j="4" />
+    <default revision="master" remote="prpl" sync-j="4" />
 
-	<project path="prplMesh" name="prplMesh"/>
+    <!-- upstream boardfarm -->
+    <project path="boardfarm" remote="boardfarm" name="boardfarm" revision="228c3434fe12d596d740a6ab6635dd5f44fa2ae7" />
 </manifest>


### PR DESCRIPTION
As part of boardfarm integration into prplMesh, we need to have
a copy of boardfarm repo to work with, because boardfarm isn't deployed
in form of stand-alone package.

Added boardfarm remote source to manifest, its sources will be fetched
into 3rdparty/boardfarm.
So far, we don't have necessity to modify boardfarm's sources,
so it was picked a commit by Apr 6, 2020.

Signed-off-by: Oleksii Ponomarenko <o.ponomarenko@inango-systems.com>