### PR TITLE
default.xml: hotfix for boardfarm remote source

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,6 +2,7 @@
 
 <manifest>
     <remote name="prpl" fetch="https://github.com/prplfoundation/" pushurl="ssh://git@github.com/prplfoundation" />
+    <remote name="boardfarm" fetch="https://github.com/mattsm/" />
 
     <default revision="master" remote="prpl" sync-j="4" />
 


### PR DESCRIPTION
I've missed boardfarm remote source during rebase while removing
all non-prplMesh sources in manifest. Fixed that.

Signed-off-by: Oleksii Ponomarenko <o.ponomarenko@inango-systems.com>