### PR TITLE
default.xml: deliver boardfarm alongside prplMesh

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,8 +2,11 @@
 
 <manifest>
     <remote name="prpl" fetch="https://github.com/prplfoundation/" pushurl="ssh://git@github.com/prplfoundation" />
+    <remote name="boardfarm" fetch="https://github.com/mattsm/" />
 
-	<default revision="master" remote="prpl" sync-j="4" />
+    <default revision="master" remote="prpl" sync-j="4" />
 
-	<project path="prplMesh" name="prplMesh"/>
+    <project path="prplMesh" name="prplMesh"/>
+    <!-- upstream boardfarm -->
+    <project path="boardfarm" remote="boardfarm" name="boardfarm" revision="228c3434fe12d596d740a6ab6635dd5f44fa2ae7" />
 </manifest>


### PR DESCRIPTION
As part of boardfarm integration into prplMesh, we need to have
a copy of boardfarm repo to work with, because boardfarm isn't deployed
in form of stand-alone package.

Added boardfarm remote source to manifest, its sources will be fetched
into 3rdparty/boardfarm.
So far, we don't have necessity to modify boardfarm's sources,
so it was picked a commit by Apr 6, 2020.

Signed-off-by: Oleksii Ponomarenko <o.ponomarenko@inango-systems.com>