### PR TITLE
default.xml: hotfix for boken manifest

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,6 +6,8 @@
 
     <default revision="master" remote="prpl" sync-j="4" />
 
+    <project path="prplMesh" name="prplMesh"/>
+
     <!-- upstream boardfarm -->
     <project path="boardfarm" remote="boardfarm" name="boardfarm" revision="228c3434fe12d596d740a6ab6635dd5f44fa2ae7" />
 </manifest>


### PR DESCRIPTION
Previously, I've removed line which states where prplMesh repo
will be cloned to - I've done that in same commit where added
boardfarm remote source.

Now that issue was fixed and checked.

Signed-off-by: Oleksii Ponomarenko <o.ponomarenko@inango-systems.com>