### PR TITLE
default.xml: modify boardfarm remote source

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,8 +6,6 @@
 
     <default revision="master" remote="prpl" sync-j="4" />
 
-    <project path="prplMesh" name="prplMesh"/>
-
-    <!-- upstream boardfarm -->
-    <project path="boardfarm" remote="boardfarm" name="boardfarm" revision="228c3434fe12d596d740a6ab6635dd5f44fa2ae7" />
+    <project path="prplMesh" name="prplMesh" />
+    <project path="boardfarm" name="boardfarm" />
 </manifest>


### PR DESCRIPTION
Changed boardfarm remote source to use prpl Foundation's fork,
which was updated with latest upstream and now become suitable
for developing purposes.

Signed-off-by: Oleksii Ponomarenko <o.ponomarenko@inango-systems.com>